### PR TITLE
 Enable to access validator instance in #call method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ Metrics/MethodLength:
 
 Metrics/LineLength:
   Max: 120
+
+Style/Documentation:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+This change log adheres to [keepachangelog.com](http://keepachangelog.com).
+
+## [Unreleased]
+### Added
+- Enable to access validator instance in `#call` method.
+- Use yard.
+
+### [0.1.0] - 2018-09-03
+- Initial release
+
+[Unreleased]: https://github.com/increments/active_interactor/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/increments/active_interactor/compare/7de7624...v0.1.0

--- a/spec/active_interactor_spec.rb
+++ b/spec/active_interactor_spec.rb
@@ -114,4 +114,25 @@ RSpec.describe ActiveInteractor do
     expect(result).to be_failure
     expect(result.errors.full_messages).to eq ['custom error message']
   end
+
+  example 'using #validator' do
+    interactor_class = Class.new do
+      include ActiveInteractor
+
+      validations do
+        def something
+          1
+        end
+      end
+
+      expose :exposure
+
+      def call
+        @exposure = validator.something
+      end
+    end
+
+    result = interactor_class.new.call
+    expect(result.exposure).to eq 1
+  end
 end


### PR DESCRIPTION
so we can reuse AR instance loaded by validator:

```rb
class AddStar
  validations(:article_id) do
    validates :article, presence: true

    def article
      @article ||= Article.find(article_id)
    end
  end

  def call(article_id:)
    validator.article.add_star
  end
end
```